### PR TITLE
Allow custom riscv toolchain paths

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -32,21 +32,35 @@ fn main() {
                .define("printf(...)", Some(""));
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        base_config.compiler("/usr/bin/clang")
-        .flag("--sysroot=/tmp/riscv32im-osx-arm64/riscv32-unknown-elf") // https://github.com/riscv-collab/riscv-gnu-toolchain has been built and stored in /opt/riscv
-        .flag("--gcc-toolchain=/tmp/riscv32im-osx-arm64") // https://github.com/riscv-collab/riscv-gnu-toolchain has been built and stored in /opt/riscv
-        .no_default_flags(true)
-        .flag("-O3")
-        .flag("--target=riscv32-unknown-none-elf")
-        .flag("-mabi=ilp32")
-        .flag("-mcmodel=medany")
-        .flag("-Os")
-        .flag("-fdata-sections")
-        .flag("-ffunction-sections")
-        .flag("-dead_strip")
-        .flag("-flto")
-        .flag("-march=rv32im")
-        .target("riscv32-unknown-none-elf");
+        const DEFAULT_RISCV_GNU_TOOLCHAIN: &str = "/opt/riscv";
+        println!("cargo:rerun-if-env-changed=RISCV_GNU_TOOLCHAIN");
+
+        let riscv_gnu_toolchain_path = env::var("RISCV_GNU_TOOLCHAIN").unwrap_or_else(|_| {
+            println!("cargo:warning=Variable RISCV_GNU_TOOLCHAIN unset. Assuming '{DEFAULT_RISCV_GNU_TOOLCHAIN}'");
+            println!("cargo:warning=Please make sure to build riscv toolchain:");
+            println!("cargo:warning=  git clone https://github.com/riscv-collab/riscv-gnu-toolchain && cd riscv-gnu-toolchain");
+            println!("cargo:warning=  export RISCV_GNU_TOOLCHAIN={DEFAULT_RISCV_GNU_TOOLCHAIN}");
+            println!("cargo:warning=  configure --prefix=\"$RISCV_GNU_TOOLCHAIN\" --with-arch=rv32im --with-abi=ilp32");
+            println!("cargo:warning=  make -j$(nproc)");
+
+            // if unset, try the default and fail eventually
+            DEFAULT_RISCV_GNU_TOOLCHAIN.into()
+        });
+
+        base_config
+            .compiler("clang")
+            .no_default_flags(true)
+            .flag(&format!("--sysroot={riscv_gnu_toolchain_path}/riscv32-unknown-elf"))
+            .flag(&format!("--gcc-toolchain={riscv_gnu_toolchain_path}"))
+            .flag("--target=riscv32-unknown-none-elf")
+            .flag("-march=rv32im")
+            .flag("-mabi=ilp32")
+            .flag("-mcmodel=medany")
+            .flag("-Os")
+            .flag("-fdata-sections")
+            .flag("-ffunction-sections")
+            .flag("-flto")
+            .target("riscv32-unknown-none-elf");
     }
 
     if cfg!(feature = "lowmemory") {


### PR DESCRIPTION
Cleaned up flags a bit.
Both -O3 and -Os were set, I left the -Os but if you want I can switch to O3.

The other thing is that previously the paths were hardcoded I think for apple devices, could you check if this still builds properly on your Macs?